### PR TITLE
Update for Puppet 4 compatibility

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,6 +5,6 @@ class needrestart(
   $package_name   = $needrestart::params::package_name,
 ) inherits needrestart::params {
 
-  include install
-  include config
+  include needrestart::install
+  include needrestart::config
 }


### PR DESCRIPTION
Hi, the init.pp is not compatible with Puppet 4.

You include needrestart::install with `include install` (without the scope).

In this PR, this is fixed.

Thanks for the module, it is very helpful!

Kind regards,
Ger.