### PR TITLE
add basic testing infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+Gemfile.lock
+vendor/
+.bundle/

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,12 @@ rvm:
   - 2.1
   - 2.2
 
+matrix:
+  exclude:
+    - rvm: 2.2
+      env: PUPPET_VERSION="~> 3.7.0"
+    - rvm: 2.2
+      env: PUPPET_VERSION="~> 3.8.0"
+
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+---
+language: ruby
+script: "bundle exec rake test"
+sudo: false
+env:
+  - PUPPET_VERSION="~> 3.7.0"
+  - PUPPET_VERSION="~> 3.8.0"
+  - PUPPET_VERSION="~> 4.1.0"
+  - PUPPET_GEM_VERSION="~> 4.2.0"
+
+rvm:
+  - 1.9.3
+  - 2.1
+  - 2.2
+  - 2.3
+
+notifications:
+  email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ env:
   - PUPPET_VERSION="~> 3.7.0"
   - PUPPET_VERSION="~> 3.8.0"
   - PUPPET_VERSION="~> 4.1.0"
-  - PUPPET_GEM_VERSION="~> 4.2.0"
+  - PUPPET_VERSION="~> 4.2.0"
 
 rvm:
   - 1.9.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ rvm:
   - 1.9.3
   - 2.1
   - 2.2
-  - 2.3
 
 notifications:
   email: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,8 @@
+source 'https://rubygems.org'
+
+puppetversion = ENV.key?('PUPPET_VERSION') ? "#{ENV['PUPPET_VERSION']}" : ['>= 3.3']
+gem 'puppet', puppetversion
+gem 'puppetlabs_spec_helper', '>= 0.8.2'
+gem 'puppet-lint', '>= 1.0.0'
+gem 'facter', '>= 1.7.0'
+gem 'metadata-json-lint'

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,47 @@
+require 'rubygems'
+require 'bundler/setup'
+
+require 'puppetlabs_spec_helper/rake_tasks'
+require 'puppet/version'
+require 'puppet-lint/tasks/puppet-lint'
+require 'puppet-syntax/tasks/puppet-syntax'
+
+begin
+    require 'puppet_blacksmith/rake_tasks'
+rescue LoadError
+end
+
+Rake::Task[:lint].clear
+
+
+PuppetLint.configuration.send('disable_80chars')
+
+exclude_paths = [
+  "bundle/**/*",
+  "pkg/**/*",
+  "vendor/**/*",
+  "spec/**/*",
+]
+PuppetSyntax.exclude_paths = exclude_paths
+PuppetLint.configuration.ignore_paths = exclude_paths
+
+desc "Validate manifests, templates, and ruby files"
+task :validate do
+  Dir['manifests/**/*.pp'].each do |manifest|
+    sh "puppet parser validate --noop #{manifest}"
+  end
+  Dir['spec/**/*.rb','lib/**/*.rb'].each do |ruby_file|
+    sh "ruby -c #{ruby_file}" unless ruby_file =~ /spec\/fixtures/
+  end
+  Dir['templates/**/*.erb'].each do |template|
+    sh "erb -P -x -T '-' #{template} | ruby -c"
+  end
+end
+
+desc "Run syntax, lint, and spec tests."
+task :test => [
+  :syntax,
+  :lint,
+  :spec,
+  :metadata_lint,
+]

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,6 +1,12 @@
 require 'spec_helper'
 describe 'needrestart' do
-  context 'with default values for all parameters' do
+  context 'with default values for all parameters on Debian' do
+    let(:facts) { { :operatingsystem => 'Debian' } }
+    it { should contain_class('needrestart') }
+  end
+
+  context 'with default values for all parameters on Ubuntu 16.04' do
+    let(:facts) { { :operatingsystem => 'Ubuntu', :lsbdistrelease => '16.04'  } }
     it { should contain_class('needrestart') }
   end
 end


### PR DESCRIPTION
This adds a base for testing, including integration of travis-ci with several combinations of puppet and ruby versions. The two included tests are just meant as a start for more testing to be possibly added later on.