### PR TITLE
fix wrong quote function for regexps in config file

### DIFF
--- a/templates/needrestart.conf.erb
+++ b/templates/needrestart.conf.erb
@@ -5,7 +5,7 @@
 #   Thomas Liske <thomas@fiasko-nw.net>
 #
 # Copyright Holder:
-#   2013 - 2015 (C) Thomas Liske [http://fiasko-nw.net/~thomas/]
+#   2013 - 2017 (C) Thomas Liske [http://fiasko-nw.net/~thomas/]
 #
 # License:
 #   This program is free software; you can redistribute it and/or modify
@@ -52,13 +52,13 @@ $nrconf{ui} = 'NeedRestart::UI::<%= @preferred_ui %>';
 # Blacklist binaries (list of regex).
 $nrconf{blacklist} = [
     # ignore sudo (not a daemon)
-    q(^/usr/bin/sudo(\.dpkg-new)?$),
+    qr(^/usr/bin/sudo(\.dpkg-new)?$),
 
     # ignore DHCP clients
-    q(^/sbin/(dhclient|dhcpcd5|pump|udhcpc)(\.dpkg-new)?$),
+    qr(^/sbin/(dhclient|dhcpcd5|pump|udhcpc)(\.dpkg-new)?$),
 
     # ignore apt-get (Debian Bug#784237)
-    q(^/usr/bin/apt-get(\.dpkg-new)?$),
+    qr(^/usr/bin/apt-get(\.dpkg-new)?$),
 ];
 
 # Blacklist services (list of regex) - USE WITH CARE.
@@ -70,46 +70,46 @@ $nrconf{blacklist} = [
 # Override service default selection (hash of regex).
 $nrconf{override_rc} = {
     # DBus
-    q(^dbus) => 0,
+    qr(^dbus) => 0,
 
     # display managers
-    q(^gdm) => 0,
-    q(^kdm) => 0,
-    q(^nodm) => 0,
-    q(^sddm) => 0,
-    q(^wdm) => 0,
-    q(^xdm) => 0,
-    q(^lightdm) => 0,
+    qr(^gdm) => 0,
+    qr(^kdm) => 0,
+    qr(^nodm) => 0,
+    qr(^sddm) => 0,
+    qr(^wdm) => 0,
+    qr(^xdm) => 0,
+    qr(^lightdm) => 0,
 
     # networking stuff
-    q(^network-manager) => 0,
-    q(^NetworkManager) => 0,
-    q(^wpa_supplicant) => 0,
-    q(^openvpn) => 0,
-    q(^quagga) => 0,
-    q(^tinc) => 0,
+    qr(^network-manager) => 0,
+    qr(^NetworkManager) => 0,
+    qr(^wpa_supplicant) => 0,
+    qr(^openvpn) => 0,
+    qr(^quagga) => 0,
+    qr(^tinc) => 0,
 
     # gettys
-    q(^getty@.+\.service) => 0,
+    qr(^getty@.+\.service) => 0,
 
     # systemd --user
-    q(^user@\d+\.service) => 0,
+    qr(^user@\d+\.service) => 0,
 
     # misc
-    q(^zfs-fuse) => 0,
-    q(^mythtv-backend) => 0,
+    qr(^zfs-fuse) => 0,
+    qr(^mythtv-backend) => 0,
 
     # workaround for broken systemd-journald
     # (see also Debian Bug#771122 & #771254)
-    q(^systemd-journald) => 0,
+    qr(^systemd-journald) => 0,
 
     # more systemd stuff
     # (see also Debian Bug#784238 & #784437)
-    q(^emergency\.service$) => 0,
-    q(^rescue\.service$) => 0,
+    qr(^emergency\.service$) => 0,
+    qr(^rescue\.service$) => 0,
 
     # don't restart systemd-logind, see #798097
-    q(^systemd-logind) => 0,
+    qr(^systemd-logind) => 0,
 };
 
 # Disable interpreter scanners.

--- a/templates/needrestart_customisations.conf.erb
+++ b/templates/needrestart_customisations.conf.erb
@@ -4,7 +4,7 @@
 <% @ignorelist.each do | name, services | -%>
 #<%= name %>
 <% services.sort.each do | service | -%>
-$nrconf{override_rc}->{q(^<%= service %>)} = 0;
+$nrconf{override_rc}->{qr(^<%= service %>)} = 0;
 <% end -%>
 
 <% end -%>


### PR DESCRIPTION
corresponds to commit 3a5c39ca8192b22ba03208a8c3e186d263fb6f62
upstream.

See also: Debian bug #844283