### PR TITLE
add has_pam_systemd parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,6 +6,7 @@ class needrestart(
   $notify_user_obsolete_binaries = $needrestart::params::notify_user_obsolete_binaries,
   $package_ensure                = $needrestart::params::package_ensure,
   $package_name                  = $needrestart::params::package_name,
+  $has_pam_systemd               = $needrestart::params::has_pam_systemd,
 ) inherits needrestart::params {
 
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -6,4 +6,5 @@ class needrestart::params(
   $ignorelist                    = {},
   $package_ensure                = 'installed',
   $package_name                  = 'needrestart',
+  $has_pam_systemd               = false,
 ){}

--- a/templates/needrestart.conf.erb
+++ b/templates/needrestart.conf.erb
@@ -30,6 +30,16 @@
 # Path of user notification scripts.
 #$nrconf{notify_d} = '/etc/needrestart/notify.d';
 
+# If needrestart detects systemd it assumes that you use systemd's pam module.
+# This allows needrestart to easily detect user session. In case you use
+# systemd *without* pam_systemd.so you should set has_pam_systemd to false
+# to enable legacy session detection!
+<% if @has_pam_systemd == true -%>
+$nrconf{has_pam_systemd} = 1;
+<% else -%>
+#$nrconf{has_pam_systemd} = 0;
+<% end -%>
+
 # Disable sending notifications to user sessions running obsolete binaries
 # using scripts from $nrconf{notify_d}.
 #$nrconf{sendnotify} = 0;


### PR DESCRIPTION
If needrestart detects systemd it assumes that you use systemd's pam module.
This allows needrestart to easily detect user session. In case you use
systemd *without* pam_systemd.so you should set has_pam_systemd to false
to enable legacy session detection!

upstream commit: 6a29143e1c6439e1f851b172e468aeef17b261b2