### PR TITLE
implement config hash to overwrite package config

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,12 +1,26 @@
-class needrestart::config inherits needrestart {
+#
+# class to configure needrestart
+#
+# Parameters:
+#
+# [*overwrite_default_conf*]
+#  set this to false if you do not want to overwrite
+#  needrestart.conf installed from the package maintainer.
+#  defaults to true.
+#
+class needrestart::config (
+  $overwrite_default_conf = true,
+) inherits needrestart {
 
-  file {'/etc/needrestart/needrestart.conf':
-    owner   => 'root',
-    group   => 'root',
-    mode    => '0644',
-    content => template('needrestart/needrestart.conf.erb'),
-    require => Class['needrestart::install'],
-  } ->
+  if $overwrite_default_conf {
+    file {'/etc/needrestart/needrestart.conf':
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0644',
+      content => template('needrestart/needrestart.conf.erb'),
+      require => Class['needrestart::install'],
+    }
+  }
 
   file {'/etc/needrestart/conf.d/':
     ensure  => 'directory',
@@ -14,13 +28,19 @@ class needrestart::config inherits needrestart {
     group   => 'root',
     mode    => '0755',
     require => Class['needrestart::install'],
+    purge   => true,
+    recurse => true,
   } ->
 
-  file {'/etc/needrestart/conf.d/customisations.conf':
+  file {'/etc/needrestart/conf.d/README.needrestart':
+    require => Class['needrestart::install'],
+  } ->
+
+  file {'/etc/needrestart/conf.d/overwrite.conf':
     owner   => 'root',
     group   => 'root',
     mode    => '0644',
-    content => template('needrestart/needrestart_customisations.conf.erb'),
+    content => epp('needrestart/overwrite.conf', { 'configs' => $needrestart::configs }),
     require => Class['needrestart::install'],
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,3 +1,21 @@
+#
+# main class for needrestart
+#
+# Parameters:
+# [*configs*]
+#   hash of configuration parameters to overwrite from default.
+#   Example (hiera):
+#   needrestart::configs:
+#     ui_mode: 'a'
+#     restart: 'l'
+#     defno: 0
+#     blacklist:
+#       - 'qr(^/usr/bin/sudo(\.dpkg-new)?$)'
+#       - 'qr(^/sbin/(dhclient|dhcpcd5|pump|udhcpc)(\.dpkg-new)?$)'
+#     override_rc:
+#       'qr(^dbus)': 0
+#       'qr(^gdm)': 0
+#
 class needrestart(
   $action                        = $needrestart::params::action,
   $preferred_ui                  = $needrestart::params::preferred_ui,
@@ -6,6 +24,7 @@ class needrestart(
   $notify_user_obsolete_binaries = $needrestart::params::notify_user_obsolete_binaries,
   $package_ensure                = $needrestart::params::package_ensure,
   $package_name                  = $needrestart::params::package_name,
+  $configs                       = {},
 ) inherits needrestart::params {
 
 

--- a/templates/overwrite.conf.epp
+++ b/templates/overwrite.conf.epp
@@ -1,0 +1,20 @@
+<%- | Hash $configs = {},
+| -%>
+# managed with puppet (module needrestart)
+<% $configs.each | $index, $value | { -%>
+
+<% if ( $value =~ String ) { -%>$nrconf{<%= $index %>} = '<%= $value %>';
+<% } -%>
+<% if ( $value =~ Integer ) { -%>$nrconf{<%= $index %>} = <%= $value %>;
+<% } -%>
+<% if ( $value =~ Array ) { -%>$nrconf{<%= $index %>} = [
+    <%= $value.join(",\n   ") %>,
+];
+<% } -%>
+<% if ( $value =~ Hash ) { -%>$nrconf{<%= $index %>} = {
+<% $value.each | $i, $v | { -%>
+    <%= $v %> => <%= $i %>,
+<% } -%>
+};
+<% } -%>
+<% } -%>


### PR DESCRIPTION
this also adds a parameter to disable the overwrite of the
package maintainers needrestart.conf file.
with the new configs parameter you can overwrite single values.