### PR TITLE
use proper defaults for class

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,7 +1,7 @@
 #
 # class to configure needrestart
 #
-class needrestart::config ( $config_overrides = lookup('needrestart::configs', Hash, 'deep', { 'default_value' => $needrestart::configs})
+class needrestart::config ( $config_overrides = lookup('needrestart::configs', Hash, 'deep', $needrestart::configs)
   ) inherits needrestart {
 
   file {'/etc/needrestart/conf.d/':


### PR DESCRIPTION
This partly resolves a configuration issue I'm having when deploying
settings from the class directly (instead of Hiera).

See #17