### PR TITLE
do not remove existing README file

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -51,6 +51,9 @@ class needrestart(
       purge   => true,
       recurse => true,
     }
+    file { '/etc/needrestart/conf.d/README.needrestart':
+      ensure => 'present',
+    }
 
     unless $configs == {} {
       class { 'needrestart::config':


### PR DESCRIPTION
The Debian package ships a useful README file and it doesn't seem
relevant to forcibly remove it.

This will keep the existing file, if it exists. If the previous
version of this code was ran, however, it will create an empty
file. That still seems preferable to removing the file altogether or
trying to synchronise the file's content with the module eternally.