### PR TITLE
Bugfix - add to, do not overwrite default override_rc hash

### DIFF
--- a/templates/overrides.conf.epp
+++ b/templates/overrides.conf.epp
@@ -11,18 +11,17 @@
     <%= $value.join(",\n   ") %>,
 ];
 <% } -%>
-<% if ( $value =~ Hash ) { -%>$nrconf{<%= $index %>} = {
+<% if ( $value =~ Hash ) { -%>
 <% $value.each | $i, $v | { -%>
     <%- if ( $v =~ String ) { -%>
-    <%= $i %> => '<%= $v %>',
+    $nrconf{<%= $index %>}{<%= $i %>} = '<%= $v %>',
     <%- } elsif ( $v =~ Array ) { -%>
-    <%= $i %> = [
+    $nrconf{<%= $index %>}{<%= $i %>} = [
         <%= $v.join(",\n        ") %>
     ];
     <%- } else { -%>
-    <%= $i %> => <%= $v %>,
+    $nrconf{<%= $index %>}{<%= $i %>} = <%= $v %>,
     <%- } -%>
 <% } -%>
-};
 <% } -%>
 <% } -%>


### PR DESCRIPTION
Changing the format will prevent the default override_rc hash from being overwritten by custom overrides hash.
custom overrides will now be added to the override_rc hash